### PR TITLE
Remove some nones

### DIFF
--- a/src/pygetfacl/acl_info_retriever.py
+++ b/src/pygetfacl/acl_info_retriever.py
@@ -23,15 +23,14 @@ class ACLInfoRetriever:
     def getfacl_raw(self) -> str:
         return sc.SubProcessCaller(
             # -E option --> don't show effective permissions
+            # (calc'ing ep based on mask easier than parsing)
             command=["getfacl", "-E", str(self._path)]
         ).call_with_stdout_capture()
 
     def getfacl(self) -> dc.ACLData:
         """
         Gets ACL info for self._path
-        :return: a :class: `GetFaclResult` object composed of raw string output
-        from a subprocess call to system getfacl, and a :class: `ACLData`
-        object
+        :return: a :class: `ACLData` object
         """
         raw_output = self.getfacl_raw()
 

--- a/src/pygetfacl/data_containers.py
+++ b/src/pygetfacl/data_containers.py
@@ -89,7 +89,7 @@ class EffectivePermissions:
                 group: fs.compute_effective_permissions(
                     base=permission, mask=acl_data.default_mask
                 )
-                for group, permission in acl_data.special_groups.items()
+                for group, permission in acl_data.default_special_groups.items()
             }
 
         self.default_other = acl_data.default_other

--- a/src/pygetfacl/data_containers.py
+++ b/src/pygetfacl/data_containers.py
@@ -43,13 +43,11 @@ class ACLData:
                 item.regex, cmd_output, flags=re.MULTILINE
             )
             item.validate_matches(matched_vals)
-            # kwargs[item.attribute] = item.to_dict_entry(matched_vals)
             kwargs[item.attribute] = item.to_acl_constructor_format(
                 matched_vals
             )
         return cls(**kwargs)
 
-    @property
     def effective_permissions(self):
         return EffectivePermissions(self)
 
@@ -100,38 +98,3 @@ class EffectivePermissions:
         return "\n".join([f"{key}: {val}" for key, val in vars(self).items()])
 
 
-class GetFaclResult:
-    """
-    Container for :class: `ACLData` and corresponding Linux getfacl std out
-    """
-
-    def __init__(self, raw_std_out: str, acl_data: ACLData):
-        """
-        Constructor
-        :param raw_std_out: string obtained from Linux getfacl std out
-        :param acl_data: :class: `ACLData` object
-        """
-        self._acl_data = acl_data
-        self._raw_std_out = raw_std_out
-
-    @property
-    def acl_data(self) -> ACLData:
-        """
-        :return: :py:attr:`~_acl_data`
-        """
-        return self._acl_data
-
-    @property
-    def raw_std_out(self):
-        """
-        :return: :py:attr:`~_raw_std_out`
-        """
-        return self._raw_std_out
-
-    def __repr__(self):
-        """
-        Special method used when passing :class: `GetFaclResult` to print()
-        :return: :py:attr:`~_raw_std_out` with leading and trailing whitespace
-        removed
-        """
-        return self._raw_std_out.strip()

--- a/src/pygetfacl/file_setting.py
+++ b/src/pygetfacl/file_setting.py
@@ -25,6 +25,13 @@ class PermissionSetting:
         self._w = w
         self._x = x
 
+    def __eq__(self, other):
+        return all([
+            self._r == other.r,
+            self._w == other.w,
+            self._x == other.x
+        ])
+
     def __repr__(self):
         r_char = "r" if self._r else "-"
         w_char = "w" if self._w else "-"

--- a/src/pygetfacl/file_setting.py
+++ b/src/pygetfacl/file_setting.py
@@ -1,3 +1,4 @@
+from pygetfacl.aclpath_exceptions import InvalidFileSettingString
 from dataclasses import dataclass
 
 
@@ -7,16 +8,27 @@ def validate_bit_string(
     no_bits_set_repr: str,
     required_length: int,
 ):
-    assert len(bit_string) == required_length
-    assert len(all_bits_set_repr) == required_length
-    assert len(no_bits_set_repr) == required_length
-    assert all(
-        [
-            (bit_string[i] == all_bits_set_repr[i])
-            or (bit_string[i] == no_bits_set_repr[i])
-            for i in range(len(bit_string))
-        ]
-    )
+    if (
+        (not len(bit_string) == required_length)
+        or (not len(all_bits_set_repr) == required_length)
+        or (not len(no_bits_set_repr) == required_length)
+        or (
+            not all(
+                [
+                    (bit_string[i] == all_bits_set_repr[i])
+                    or (bit_string[i] == no_bits_set_repr[i])
+                    for i in range(len(bit_string))
+                ]
+            )
+        )
+    ):
+        raise InvalidFileSettingString(
+            value=bit_string,
+            all_bits_set=all_bits_set_repr,
+            no_bits_set=no_bits_set_repr,
+        )
+    # except AssertionError:
+    #     raise InvalidFileSettingString
 
 
 class PermissionSetting:
@@ -26,11 +38,9 @@ class PermissionSetting:
         self._x = x
 
     def __eq__(self, other):
-        return all([
-            self._r == other.r,
-            self._w == other.w,
-            self._x == other.x
-        ])
+        return all(
+            [self._r == other.r, self._w == other.w, self._x == other.x]
+        )
 
     def __repr__(self):
         r_char = "r" if self._r else "-"
@@ -77,9 +87,7 @@ def compute_effective_permissions(
 
 
 class FlagSetting:
-    def __init__(
-        self, uid: bool, gid: bool, sticky: bool
-    ):
+    def __init__(self, uid: bool, gid: bool, sticky: bool):
         self._uid = uid
         self._gid = gid
         self._sticky = sticky

--- a/src/pygetfacl/output_spec.py
+++ b/src/pygetfacl/output_spec.py
@@ -51,11 +51,16 @@ class ItemFromGetFacl:
                 self.attribute, len(matched_groups)
             )
 
-    def to_acl_constructor_format(self, matched_groups: list[str]):
+    def to_max_one_item_acl_format(self, matched_groups: list[str]):
+        assert len(matched_groups) <= 1
         if len(matched_groups) == 0:
             return None
-        if (len(matched_groups) == 1) and (self.max_entries == 1):
+        else:
             return self.acl_data_type(matched_groups[0].strip())
+
+    def to_multi_item_acl_format(self, matched_groups: list[str]):
+        if len(matched_groups) == 0:
+            return {}
         else:
             pairs = [item.split(":") for item in matched_groups]
             assert all([len(pair) == 2 for pair in pairs])
@@ -63,6 +68,23 @@ class ItemFromGetFacl:
                 name: self.acl_data_type(permission)
                 for name, permission in pairs
             }
+
+    def to_acl_constructor_format(self, matched_groups: list[str]):
+        if self.max_entries == 1:
+            return self.to_max_one_item_acl_format(matched_groups=matched_groups)
+        else:
+            return self.to_multi_item_acl_format(matched_groups=matched_groups)
+        # if len(matched_groups) == 0:
+        #     return None
+        # if (len(matched_groups) == 1) and (self.max_entries == 1):
+        #     return self.acl_data_type(matched_groups[0].strip())
+        # else:
+        #     pairs = [item.split(":") for item in matched_groups]
+        #     assert all([len(pair) == 2 for pair in pairs])
+        #     return {
+        #         name: self.acl_data_type(permission)
+        #         for name, permission in pairs
+        #     }
 
     # def to_dict_entry(self, matched_groups: list[str]):
     #     if len(matched_groups) == 0:

--- a/src/pygetfacl/output_spec.py
+++ b/src/pygetfacl/output_spec.py
@@ -64,15 +64,15 @@ class ItemFromGetFacl:
                 for name, permission in pairs
             }
 
-    def to_dict_entry(self, matched_groups: list[str]):
-        if len(matched_groups) == 0:
-            return None
-        if (len(matched_groups) == 1) and (self.max_entries == 1):
-            return matched_groups[0].strip()
-        else:
-            key_vals = [item.split(":") for item in matched_groups]
-            assert all([len(pair) == 2 for pair in key_vals])
-            return {key: value for key, value in key_vals}
+    # def to_dict_entry(self, matched_groups: list[str]):
+    #     if len(matched_groups) == 0:
+    #         return None
+    #     if (len(matched_groups) == 1) and (self.max_entries == 1):
+    #         return matched_groups[0].strip()
+    #     else:
+    #         key_vals = [item.split(":") for item in matched_groups]
+    #         assert all([len(pair) == 2 for pair in key_vals])
+    #         return {key: value for key, value in key_vals}
 
 
 def getfacl_output_items() -> list[ItemFromGetFacl]:

--- a/src/test_pygetfacl/test_acl_info_retriever.py
+++ b/src/test_pygetfacl/test_acl_info_retriever.py
@@ -5,7 +5,9 @@ import pygetfacl
 
 def test_getfacl():
     result = pygetfacl.getfacl(Path.cwd())
+
     print("hold for debugger")
+
 
 def test_getfacl_raw():
     pygetfacl.getfacl_raw(Path.cwd())

--- a/src/test_pygetfacl/test_acl_info_retriever.py
+++ b/src/test_pygetfacl/test_acl_info_retriever.py
@@ -1,13 +1,27 @@
 from pathlib import Path
+import os
 import pygetfacl
-# import pytest
+import pytest
+import subprocess
 
 
-def test_getfacl():
-    result = pygetfacl.getfacl(Path.cwd())
+@pytest.fixture
+def temp_dir_with_some_facl_settings(tmp_path) -> Path:
+    my_dir = tmp_path / "test_dir"
+    my_dir.mkdir()
+    subprocess.check_call(["setfacl", "-bn", str(my_dir)])
+    subprocess.check_call(
+        ["setfacl", "-m", f"u:{os.getlogin()}:rwx", str(my_dir)]
+    )
+    subprocess.check_call(["setfacl", "-d", "-m", "g::rwx", str(my_dir)])
+    subprocess.check_call(["chmod", "g+s", str(my_dir)])
 
-    print("hold for debugger")
+    yield my_dir
 
 
-def test_getfacl_raw():
-    pygetfacl.getfacl_raw(Path.cwd())
+def test_getfacl(temp_dir_with_some_facl_settings):
+    result = pygetfacl.getfacl(temp_dir_with_some_facl_settings)
+
+
+def test_getfacl_raw(temp_dir_with_some_facl_settings):
+    pygetfacl.getfacl_raw(temp_dir_with_some_facl_settings)

--- a/src/test_pygetfacl/test_file_settings.py
+++ b/src/test_pygetfacl/test_file_settings.py
@@ -1,5 +1,6 @@
 import pytest
-from pygetfacl.aclpath_exceptions import InvalidFileSetting
+
+from pygetfacl.aclpath_exceptions import InvalidFileSettingString
 from pygetfacl.file_setting import PermissionSetting
 
 good_permission_settings = [
@@ -13,6 +14,16 @@ good_permission_settings = [
     ("r", "-", "x"),
 ]
 
+
+@pytest.mark.parametrize(
+    "r_string, w_string, x_string", good_permission_settings
+)
+def test_good_permission_settings(r_string, w_string, x_string):
+    permissions = PermissionSetting.from_string(
+        "".join([r_string, w_string, x_string])
+    )
+
+
 bad_permission_settings = [
     ("e", "e", "e"),
     ("x", "w", "x"),
@@ -22,17 +33,10 @@ bad_permission_settings = [
 
 
 @pytest.mark.parametrize(
-    "r_string, w_string, x_string", good_permission_settings
-)
-def test_good_permission_settings(r_string, w_string, x_string):
-    permissions = PermissionSetting("".join([r_string, w_string, x_string]))
-
-
-@pytest.mark.parametrize(
     "r_string, w_string, x_string", bad_permission_settings
 )
-def test_good_permission_settings(r_string, w_string, x_string):
-    with pytest.raises(InvalidFileSetting):
-        permissions = PermissionSetting(
+def test_bad_permission_settings(r_string, w_string, x_string):
+    with pytest.raises(InvalidFileSettingString):
+        permissions = PermissionSetting.from_string(
             "".join([r_string, w_string, x_string])
         )


### PR DESCRIPTION
Modify ACLData and EffectivePermissions multi-item members: if empty, default to empty dictionary instead of `None`.